### PR TITLE
Feature: Option to confirm 'Hideout In Progress' contribution after raid.

### DIFF
--- a/Globals.cs
+++ b/Globals.cs
@@ -11,6 +11,7 @@ internal static class Globals
     public static bool AutoInstall = true;
     public static bool AutoUpgrade = true;
     public static bool Debug = false;
+    public static bool EnableHIPContributionConfirmation = true;
     public static KeyboardShortcut InvestigateKeys = new KeyboardShortcut(KeyCode.I, KeyCode.LeftControl);
     public static bool IsHideoutInProgressSupportEnabled = true;
     public static bool OnlyContributeWhenAreaRequirementsAreMet = true;

--- a/Globals.cs
+++ b/Globals.cs
@@ -11,7 +11,7 @@ internal static class Globals
     public static bool AutoInstall = true;
     public static bool AutoUpgrade = true;
     public static bool Debug = false;
-    public static bool EnableHIPContributionConfirmation = true;
+    public static bool EnableHideoutInProgressConfirmation = true;
     public static KeyboardShortcut InvestigateKeys = new KeyboardShortcut(KeyCode.I, KeyCode.LeftControl);
     public static bool IsHideoutInProgressSupportEnabled = true;
     public static bool OnlyContributeWhenAreaRequirementsAreMet = true;

--- a/HIP/HIPContributionCandidate.cs
+++ b/HIP/HIPContributionCandidate.cs
@@ -1,0 +1,26 @@
+﻿using EFT;
+using EFT.Hideout;
+using System.Collections.Generic;
+
+#nullable enable
+
+namespace HideoutAutomation.HIP
+{
+    internal class HIPContributionCandidate
+    {
+        internal HIPContributionCandidate(AreaData areaData, EAreaType areaType, ItemRequirement[] itemRequirements, List<string> itemIds, List<string> contributionMessages)
+        {
+            this.AreaData = areaData;
+            this.AreaType = areaType;
+            this.ItemRequirements = itemRequirements;
+            this.ItemIds = itemIds;
+            this.ContributionMessages = contributionMessages;
+        }
+
+        public AreaData AreaData { get; }
+        public EAreaType AreaType { get; }
+        public List<string> ContributionMessages { get; }
+        public List<string> ItemIds { get; }
+        public ItemRequirement[] ItemRequirements { get; }
+    }
+}

--- a/HideoutAutomation.Server/HideoutAutomation.Server.csproj
+++ b/HideoutAutomation.Server/HideoutAutomation.Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <Version>1.2.6</Version>
+    <Version>1.3.0</Version>
     <SPTPath>D:\Offline</SPTPath>
   </PropertyGroup>
   

--- a/HideoutAutomation.csproj
+++ b/HideoutAutomation.csproj
@@ -117,6 +117,7 @@
     <Compile Include="Helpers\ModChecker.cs" />
     <Compile Include="Helpers\RaidHelper.cs" />
     <Compile Include="Helpers\ReflectionHelper.cs" />
+    <Compile Include="HIP\HIPContributionCandidate.cs" />
     <Compile Include="MonoBehaviours\UpdateMonoBehaviour.cs" />
     <Compile Include="Patches\Application\TarkovApplication_Init.cs" />
     <Compile Include="Patches\Hideout\HideoutClass_SetInventoryController.cs" />

--- a/MonoBehaviours/UpdateMonoBehaviour.cs
+++ b/MonoBehaviours/UpdateMonoBehaviour.cs
@@ -577,7 +577,7 @@ namespace HideoutAutomation.MonoBehaviours
             foreach (HIPContributionCandidate candidate in candidates)
             {
                 lines.Add(string.Empty);
-                lines.Add($"Area: {candidate.AreaType}");
+                lines.Add($"Area: {candidate.AreaData.Template.Name}");
                 foreach (string contributionMessage in candidate.ContributionMessages)
                     lines.Add($"- {contributionMessage}");
             }

--- a/MonoBehaviours/UpdateMonoBehaviour.cs
+++ b/MonoBehaviours/UpdateMonoBehaviour.cs
@@ -5,6 +5,7 @@ using EFT.InventoryLogic;
 using EFT.UI;
 using HideoutAutomation.Construction.Requests;
 using HideoutAutomation.Helpers;
+using HideoutAutomation.HIP;
 using Newtonsoft.Json;
 using SPT.Common.Http;
 using System;
@@ -23,28 +24,6 @@ namespace HideoutAutomation.MonoBehaviours
 {
     internal class UpdateMonoBehaviour : MonoBehaviour
     {
-        private sealed class HIPContributionCandidate
-        {
-            public HIPContributionCandidate(AreaData areaData, EAreaType areaType, ItemRequirement[] itemRequirements, List<string> itemIds, List<string> contributionMessages)
-            {
-                this.AreaData = areaData;
-                this.AreaType = areaType;
-                this.ItemRequirements = itemRequirements;
-                this.ItemIds = itemIds;
-                this.ContributionMessages = contributionMessages;
-            }
-
-            public AreaData AreaData { get; }
-
-            public EAreaType AreaType { get; }
-
-            public List<string> ContributionMessages { get; }
-
-            public List<string> ItemIds { get; }
-
-            public ItemRequirement[] ItemRequirements { get; }
-        }
-
         private static readonly EAreaStatus[] interactableStatuses =
         [
             EAreaStatus.LockedToConstruct,
@@ -54,8 +33,10 @@ namespace HideoutAutomation.MonoBehaviours
         ];
 
         private readonly List<EAreaType> declinedAreaUpdates = new List<EAreaType>();
+        private readonly List<HIPContributionCandidate> hipPendingCandidates = [];
         private CancellationToken? cancellationToken;
         private CancellationTokenSource? cancellationTokenSource;
+        private bool checkHIPContributionCycle = false;
         private bool didInvestigate = false;
         private bool hipContributionDeniedThisCycle = false;
         private bool hipContributionScanCompleted = false;
@@ -66,9 +47,6 @@ namespace HideoutAutomation.MonoBehaviours
         private bool? lastRemoveSkillRequirements = null;
         private bool? lastRemoveTraderRequirements = null;
         private DateTime? lastRun = null;
-        private readonly List<HIPContributionCandidate> pendingHIPContributionCandidates = [];
-        private bool wasInRaid = false;
-
         private List<SimpleStashPanel> simpleStashPanels = [];
 
         public void Start()
@@ -81,14 +59,14 @@ namespace HideoutAutomation.MonoBehaviours
             bool hasRaidLoaded = RaidHelper.HasRaidLoaded();
             if (hasRaidLoaded)
             {
-                this.wasInRaid = true;
+                this.checkHIPContributionCycle = true;
                 this.stopCoroutines();
                 return;
             }
 
-            if (this.wasInRaid)
+            if (this.checkHIPContributionCycle)
             {
-                this.wasInRaid = false;
+                this.checkHIPContributionCycle = false;
                 this.resetHIPContributionConfirmationCycle();
             }
 
@@ -168,6 +146,22 @@ namespace HideoutAutomation.MonoBehaviours
             return field?.GetValue(panel) as ScrollRect;
         }
 
+        private string buildHIPContributionDescription(IEnumerable<HIPContributionCandidate> candidates)
+        {
+            List<string> lines = [];
+            foreach (HIPContributionCandidate candidate in candidates)
+            {
+                lines.Add($"Area: {candidate.AreaType}");
+                foreach (string contributionMessage in candidate.ContributionMessages)
+                    lines.Add($"- {contributionMessage}");
+            }
+
+            if (lines.Count == 0)
+                return string.Empty;
+
+            return $"Contribute the following Hideout In Progress items?{Environment.NewLine}{Environment.NewLine}{string.Join(Environment.NewLine, lines)}";
+        }
+
         private bool CanFindAllItems(IEnumerable<string> itemIds)
         {
             FindItemsRequest findItemsRequest = new FindItemsRequest()
@@ -216,7 +210,7 @@ namespace HideoutAutomation.MonoBehaviours
                         bool isHIPEnabled = Globals.IsHideoutInProgress
                             && Globals.IsHideoutInProgressSupportEnabled;
                         bool shouldScanHIPContributions = isHIPEnabled
-                            && Globals.EnableHIPContributionConfirmation
+                            && Globals.EnableHideoutInProgressConfirmation
                             && this.hipContributionScanCompleted == false
                             && this.hipContributionDeniedThisCycle == false;
 
@@ -235,13 +229,13 @@ namespace HideoutAutomation.MonoBehaviours
                                 && this.hideoutInProgressRequirementsAreMet(requirements);
                             if (canProcessHIPContribution)
                             {
-                                if (Globals.EnableHIPContributionConfirmation)
+                                if (Globals.EnableHideoutInProgressConfirmation)
                                 {
                                     if (shouldScanHIPContributions)
                                     {
                                         HIPContributionCandidate? candidate = this.createHIPContributionCandidate(hideout, data, areaType, requirements);
                                         if (candidate != null)
-                                            this.pendingHIPContributionCandidates.Add(candidate);
+                                            this.hipPendingCandidates.Add(candidate);
                                     }
                                 }
                                 else
@@ -302,29 +296,13 @@ namespace HideoutAutomation.MonoBehaviours
                         {
                             this.hipContributionScanCompleted = true;
                             if (Globals.Debug)
-                                LogHelper.LogInfo($"(HIP): scan complete. Candidates={this.pendingHIPContributionCandidates.Count}");
+                                LogHelper.LogInfo($"(HIP): scan complete. Candidates={this.hipPendingCandidates.Count}");
                         }
 
                         this.tryShowHIPContributionConfirmation();
                     }
                 }
             }
-        }
-
-        private string buildHIPContributionDescription(IEnumerable<HIPContributionCandidate> candidates)
-        {
-            List<string> lines = [];
-            foreach (HIPContributionCandidate candidate in candidates)
-            {
-                lines.Add($"Area: {candidate.AreaType}");
-                foreach (string contributionMessage in candidate.ContributionMessages)
-                    lines.Add($"- {contributionMessage}");
-            }
-
-            if (lines.Count == 0)
-                return string.Empty;
-
-            return $"Contribute the following Hideout In Progress items?{Environment.NewLine}{Environment.NewLine}{string.Join(Environment.NewLine, lines)}";
         }
 
         private HIPContributionCandidate? createHIPContributionCandidate(HideoutClass hideout, AreaData data, EAreaType areaType, List<Requirement> requirements)
@@ -345,7 +323,7 @@ namespace HideoutAutomation.MonoBehaviours
                     foreach (var contribution in contributions)
                     {
                         string itemId = contribution.Item.Id;
-                        string contributionMessage = $"Contributed {contribution.CurrentItemCount} of {contribution.Item.LocalizedName()} to {areaType}.";
+                        string contributionMessage = $"Contribute {contribution.CurrentItemCount} of {contribution.Item.LocalizedName()} to {areaType}.";
                         itemIds.Add(itemId);
                         contributionMessages.Add(contributionMessage);
                     }
@@ -377,22 +355,6 @@ namespace HideoutAutomation.MonoBehaviours
             }
 
             return contributed;
-        }
-
-        private IEnumerator refreshSimpleStashPanels()
-        {
-            //HACK finally found a way to hard refresh the draw of SimpleStashPanel.
-            foreach (SimpleStashPanel simpleStashPanel in this.simpleStashPanels)
-            {
-                ScrollRect? scroll = getStashScroll(simpleStashPanel);
-                float originalPosition = scroll?.verticalNormalizedPosition ?? 1.0f;
-                yield return null; //EndOfFrame
-                forceScrollRefresh(scroll, Mathf.Clamp01(originalPosition - 0.1f));
-                yield return null; //EndOfFrame
-                forceScrollRefresh(scroll, Mathf.Clamp01(originalPosition + 0.2f));
-                yield return null; //EndOfFrame
-                forceScrollRefresh(scroll, originalPosition);
-            }
         }
 
         private int getItemCount(string templateId, bool isSpawnedInSession)
@@ -485,47 +447,6 @@ namespace HideoutAutomation.MonoBehaviours
                 || this.lastRemoveItemRequirements != Globals.RemoveItemRequirements
                 || this.lastRemoveSkillRequirements != Globals.RemoveSkillRequirements
                 || this.lastRemoveTraderRequirements != Globals.RemoveTraderRequirements;
-        }
-
-        private void resetHIPContributionConfirmationCycle()
-        {
-            this.hipContributionDeniedThisCycle = false;
-            this.hipContributionScanCompleted = false;
-            this.pendingHIPContributionCandidates.Clear();
-            if (Globals.Debug)
-                LogHelper.LogInfo("(HIP): confirmation cycle reset.");
-        }
-
-        private void tryShowHIPContributionConfirmation()
-        {
-            if (Globals.EnableHIPContributionConfirmation == false
-                || this.hipContributionDeniedThisCycle
-                || this.inDialog
-                || this.pendingHIPContributionCandidates.Count == 0)
-                return;
-
-            string description = this.buildHIPContributionDescription(this.pendingHIPContributionCandidates);
-            if (string.IsNullOrWhiteSpace(description))
-                return;
-
-            HIPContributionCandidate[] candidates = this.pendingHIPContributionCandidates.ToArray();
-            this.pendingHIPContributionCandidates.Clear();
-
-            this.showDialogWindow(description, () =>
-            {
-                if (RaidHelper.HasRaidLoaded())
-                    return;
-
-                if (Globals.Debug)
-                    LogHelper.LogInfo("(HIP): contribution prompt accepted.");
-                if (this.executeHIPContributionCandidates(candidates))
-                    this.StartCoroutine(this.refreshSimpleStashPanels());
-            }, () =>
-            {
-                this.hipContributionDeniedThisCycle = true;
-                if (Globals.Debug)
-                    LogHelper.LogInfo("(HIP): contribution prompt denied.");
-            });
         }
 
         /// <summary>
@@ -625,6 +546,22 @@ namespace HideoutAutomation.MonoBehaviours
             return itemCount < handoverValue;
         }
 
+        private IEnumerator refreshSimpleStashPanels()
+        {
+            //HACK finally found a way to hard refresh the draw of SimpleStashPanel.
+            foreach (SimpleStashPanel simpleStashPanel in this.simpleStashPanels)
+            {
+                ScrollRect? scroll = getStashScroll(simpleStashPanel);
+                float originalPosition = scroll?.verticalNormalizedPosition ?? 1.0f;
+                yield return null; //EndOfFrame
+                forceScrollRefresh(scroll, Mathf.Clamp01(originalPosition - 0.1f));
+                yield return null; //EndOfFrame
+                forceScrollRefresh(scroll, Mathf.Clamp01(originalPosition + 0.2f));
+                yield return null; //EndOfFrame
+                forceScrollRefresh(scroll, originalPosition);
+            }
+        }
+
         private void reloadHideoutRequirements(HideoutClass? hideout)
         {
             this.lastRemoveAreaRequirements = null;
@@ -686,6 +623,15 @@ namespace HideoutAutomation.MonoBehaviours
             return requirements.Data;
         }
 
+        private void resetHIPContributionConfirmationCycle()
+        {
+            this.hipContributionDeniedThisCycle = false;
+            this.hipContributionScanCompleted = false;
+            this.hipPendingCandidates.Clear();
+            if (Globals.Debug)
+                LogHelper.LogInfo("(HIP): confirmation cycle reset.");
+        }
+
         private void showDialogWindow(string description, Action acceptAction, Action cancelAction)
         {
             if (this.inDialog)
@@ -724,6 +670,38 @@ namespace HideoutAutomation.MonoBehaviours
             this.StopAllCoroutines();
             if (Globals.Debug)
                 LogHelper.LogInfoWithNotification("Stopped coroutine");
+        }
+
+        private void tryShowHIPContributionConfirmation()
+        {
+            if (Globals.EnableHideoutInProgressConfirmation == false
+                || this.hipContributionDeniedThisCycle
+                || this.inDialog
+                || this.hipPendingCandidates.Count == 0)
+                return;
+
+            string description = this.buildHIPContributionDescription(this.hipPendingCandidates);
+            if (string.IsNullOrWhiteSpace(description))
+                return;
+
+            HIPContributionCandidate[] candidates = this.hipPendingCandidates.ToArray();
+            this.hipPendingCandidates.Clear();
+
+            this.showDialogWindow(description, () =>
+            {
+                if (RaidHelper.HasRaidLoaded())
+                    return;
+
+                if (Globals.Debug)
+                    LogHelper.LogInfo("(HIP): contribution prompt accepted.");
+                if (this.executeHIPContributionCandidates(candidates))
+                    this.StartCoroutine(this.refreshSimpleStashPanels());
+            }, () =>
+            {
+                this.hipContributionDeniedThisCycle = true;
+                if (Globals.Debug)
+                    LogHelper.LogInfo("(HIP): contribution prompt denied.");
+            });
         }
     }
 }

--- a/MonoBehaviours/UpdateMonoBehaviour.cs
+++ b/MonoBehaviours/UpdateMonoBehaviour.cs
@@ -576,6 +576,7 @@ namespace HideoutAutomation.MonoBehaviours
             List<string> lines = [];
             foreach (HIPContributionCandidate candidate in candidates)
             {
+                lines.Add(string.Empty);
                 lines.Add($"Area: {candidate.AreaType}");
                 foreach (string contributionMessage in candidate.ContributionMessages)
                     lines.Add($"- {contributionMessage}");
@@ -584,7 +585,7 @@ namespace HideoutAutomation.MonoBehaviours
             if (lines.Count == 0)
                 return string.Empty;
 
-            return $"Contribute the following Hideout In Progress items?{Environment.NewLine}{Environment.NewLine}{string.Join(Environment.NewLine, lines)}";
+            return $"Contribute the following Hideout In Progress items?{Environment.NewLine}{string.Join(Environment.NewLine, lines)}";
         }
 
         /// <summary>

--- a/MonoBehaviours/UpdateMonoBehaviour.cs
+++ b/MonoBehaviours/UpdateMonoBehaviour.cs
@@ -625,7 +625,7 @@ namespace HideoutAutomation.MonoBehaviours
                     foreach (var contribution in contributions)
                     {
                         string itemId = contribution.Item.Id;
-                        string contributionMessage = $"Contribute {contribution.CurrentItemCount} of {contribution.Item.LocalizedName()} to {areaType}.";
+                        string contributionMessage = $"Contribute {contribution.CurrentItemCount} of {contribution.Item.LocalizedName()}.";
                         itemIds.Add(itemId);
                         contributionMessages.Add(contributionMessage);
                     }

--- a/MonoBehaviours/UpdateMonoBehaviour.cs
+++ b/MonoBehaviours/UpdateMonoBehaviour.cs
@@ -23,6 +23,28 @@ namespace HideoutAutomation.MonoBehaviours
 {
     internal class UpdateMonoBehaviour : MonoBehaviour
     {
+        private sealed class HIPContributionCandidate
+        {
+            public HIPContributionCandidate(AreaData areaData, EAreaType areaType, ItemRequirement[] itemRequirements, List<string> itemIds, List<string> contributionMessages)
+            {
+                this.AreaData = areaData;
+                this.AreaType = areaType;
+                this.ItemRequirements = itemRequirements;
+                this.ItemIds = itemIds;
+                this.ContributionMessages = contributionMessages;
+            }
+
+            public AreaData AreaData { get; }
+
+            public EAreaType AreaType { get; }
+
+            public List<string> ContributionMessages { get; }
+
+            public List<string> ItemIds { get; }
+
+            public ItemRequirement[] ItemRequirements { get; }
+        }
+
         private static readonly EAreaStatus[] interactableStatuses =
         [
             EAreaStatus.LockedToConstruct,
@@ -35,6 +57,8 @@ namespace HideoutAutomation.MonoBehaviours
         private CancellationToken? cancellationToken;
         private CancellationTokenSource? cancellationTokenSource;
         private bool didInvestigate = false;
+        private bool hipContributionDeniedThisCycle = false;
+        private bool hipContributionScanCompleted = false;
         private bool inDialog = false;
         private bool? lastRemoveAreaRequirements = null;
         private bool? lastRemoveCurrencyRequirements = null;
@@ -42,6 +66,8 @@ namespace HideoutAutomation.MonoBehaviours
         private bool? lastRemoveSkillRequirements = null;
         private bool? lastRemoveTraderRequirements = null;
         private DateTime? lastRun = null;
+        private readonly List<HIPContributionCandidate> pendingHIPContributionCandidates = [];
+        private bool wasInRaid = false;
 
         private List<SimpleStashPanel> simpleStashPanels = [];
 
@@ -52,12 +78,21 @@ namespace HideoutAutomation.MonoBehaviours
 
         public void Update()
         {
-            if (RaidHelper.HasRaidLoaded())
+            bool hasRaidLoaded = RaidHelper.HasRaidLoaded();
+            if (hasRaidLoaded)
             {
+                this.wasInRaid = true;
                 this.stopCoroutines();
                 return;
             }
-            else if (this.cancellationToken?.IsCancellationRequested == true)
+
+            if (this.wasInRaid)
+            {
+                this.wasInRaid = false;
+                this.resetHIPContributionConfirmationCycle();
+            }
+
+            if (this.cancellationToken?.IsCancellationRequested == true)
                 this.startCoroutine();
 
             bool shouldInvestigate = Globals.Debug && Globals.InvestigateKeys.IsPressed();
@@ -78,6 +113,7 @@ namespace HideoutAutomation.MonoBehaviours
             this.stopCoroutines();
 
             this.declinedAreaUpdates.Clear();
+            this.resetHIPContributionConfirmationCycle();
             LogHelper.LogInfoWithNotification($"Declined Area(s) reset.");
 
             this.startCoroutine();
@@ -177,6 +213,13 @@ namespace HideoutAutomation.MonoBehaviours
                     }
                     if (hideout != null && hideout.AreaDatas.Count > 0)
                     {
+                        bool isHIPEnabled = Globals.IsHideoutInProgress
+                            && Globals.IsHideoutInProgressSupportEnabled;
+                        bool shouldScanHIPContributions = isHIPEnabled
+                            && Globals.EnableHIPContributionConfirmation
+                            && this.hipContributionScanCompleted == false
+                            && this.hipContributionDeniedThisCycle == false;
+
                         foreach (AreaData data in hideout.AreaDatas)
                         {
                             if (this.cancellationTokenSource.IsCancellationRequested)
@@ -187,53 +230,32 @@ namespace HideoutAutomation.MonoBehaviours
                             if (Globals.Debug)
                                 LogHelper.LogInfo($"EAreaType: {areaType}, Status={status}");
                             List<Requirement> requirements = this.removeRequirements(data);
-                            if (Globals.IsHideoutInProgress
-                                && Globals.IsHideoutInProgressSupportEnabled
+                            bool canProcessHIPContribution = isHIPEnabled
                                 && interactableStatuses.Contains(status)
-                                && this.hideoutInProgressRequirementsAreMet(requirements))
+                                && this.hideoutInProgressRequirementsAreMet(requirements);
+                            if (canProcessHIPContribution)
                             {
-                                if (Globals.Debug)
-                                    LogHelper.LogInfo($"(HIP): CheckItemRequirements.");
-
-                                List<string> itemIds = [];
-                                List<string> contributionMessages = [];
-                                ItemRequirement[] itemRequirements = requirements.OfType<ItemRequirement>().Where(r => r.Item is not MoneyItemClass).ToArray();
-                                foreach (ItemRequirement itemRequirement in itemRequirements)
+                                if (Globals.EnableHIPContributionConfirmation)
                                 {
-                                    var contributions = hideout.method_21([itemRequirement]);
-                                    if (contributions.Count > 0)
+                                    if (shouldScanHIPContributions)
                                     {
-                                        if (Globals.Debug)
-                                            LogHelper.LogInfo($"(HIP): contributions.Count={contributions.Count}");
-                                        foreach (var contribution in contributions)
-                                        {
-                                            string itemId = contribution.Item.Id;
-                                            string contributionMessage = $"Contributed {contribution.CurrentItemCount} of {contribution.Item.LocalizedName()} to {areaType}.";
-                                            itemIds.Add(itemId);
-                                            contributionMessages.Add(contributionMessage);
-                                        }
+                                        HIPContributionCandidate? candidate = this.createHIPContributionCandidate(hideout, data, areaType, requirements);
+                                        if (candidate != null)
+                                            this.pendingHIPContributionCandidates.Add(candidate);
                                     }
                                 }
-                                bool contribute = itemIds.Any() && this.CanFindAllItems(itemIds);
-                                if (contribute)
+                                else
                                 {
-                                    this.hideoutInProgressContribute(data, itemRequirements);
-                                    foreach (string contributionMessage in contributionMessages)
-                                        LogHelper.LogInfoWithNotification(contributionMessage);
-                                    //HACK finally found a way to hard refresh the draw of SimpleStashPanel.
-                                    foreach (SimpleStashPanel simpleStashPanel in this.simpleStashPanels)
+                                    HIPContributionCandidate? candidate = this.createHIPContributionCandidate(hideout, data, areaType, requirements);
+                                    if (candidate != null)
                                     {
-                                        ScrollRect? scroll = getStashScroll(simpleStashPanel);
-                                        float origionalPosition = scroll?.verticalNormalizedPosition ?? 1.0f;
-                                        yield return null; //EndOfFrame
-                                        forceScrollRefresh(scroll, Mathf.Clamp01(origionalPosition - 0.1f));
-                                        yield return null; //EndOfFrame
-                                        forceScrollRefresh(scroll, Mathf.Clamp01(origionalPosition + 0.2f));
-                                        yield return null; //EndOfFrame
-                                        forceScrollRefresh(scroll, origionalPosition);
+                                        this.hideoutInProgressContribute(candidate.AreaData, candidate.ItemRequirements);
+                                        foreach (string msg in candidate.ContributionMessages)
+                                            LogHelper.LogInfoWithNotification(msg);
+                                        yield return this.refreshSimpleStashPanels();
                                     }
+                                    yield return new WaitForSeconds(0.5f);
                                 }
-                                yield return new WaitForSeconds(0.5f);
                             }
                             switch (status)
                             {
@@ -275,8 +297,101 @@ namespace HideoutAutomation.MonoBehaviours
                                     break;
                             }
                         }
+
+                        if (shouldScanHIPContributions)
+                        {
+                            this.hipContributionScanCompleted = true;
+                            if (Globals.Debug)
+                                LogHelper.LogInfo($"(HIP): scan complete. Candidates={this.pendingHIPContributionCandidates.Count}");
+                        }
+
+                        this.tryShowHIPContributionConfirmation();
                     }
                 }
+            }
+        }
+
+        private string buildHIPContributionDescription(IEnumerable<HIPContributionCandidate> candidates)
+        {
+            List<string> lines = [];
+            foreach (HIPContributionCandidate candidate in candidates)
+            {
+                lines.Add($"Area: {candidate.AreaType}");
+                foreach (string contributionMessage in candidate.ContributionMessages)
+                    lines.Add($"- {contributionMessage}");
+            }
+
+            if (lines.Count == 0)
+                return string.Empty;
+
+            return $"Contribute the following Hideout In Progress items?{Environment.NewLine}{Environment.NewLine}{string.Join(Environment.NewLine, lines)}";
+        }
+
+        private HIPContributionCandidate? createHIPContributionCandidate(HideoutClass hideout, AreaData data, EAreaType areaType, List<Requirement> requirements)
+        {
+            if (Globals.Debug)
+                LogHelper.LogInfo($"(HIP): CheckItemRequirements.");
+
+            List<string> itemIds = [];
+            List<string> contributionMessages = [];
+            ItemRequirement[] itemRequirements = requirements.OfType<ItemRequirement>().Where(r => r.Item is not MoneyItemClass).ToArray();
+            foreach (ItemRequirement itemRequirement in itemRequirements)
+            {
+                var contributions = hideout.method_21([itemRequirement]);
+                if (contributions.Count > 0)
+                {
+                    if (Globals.Debug)
+                        LogHelper.LogInfo($"(HIP): contributions.Count={contributions.Count}");
+                    foreach (var contribution in contributions)
+                    {
+                        string itemId = contribution.Item.Id;
+                        string contributionMessage = $"Contributed {contribution.CurrentItemCount} of {contribution.Item.LocalizedName()} to {areaType}.";
+                        itemIds.Add(itemId);
+                        contributionMessages.Add(contributionMessage);
+                    }
+                }
+            }
+
+            if (itemIds.Count == 0 || this.CanFindAllItems(itemIds) == false)
+                return null;
+
+            return new HIPContributionCandidate(data, areaType, itemRequirements, itemIds, contributionMessages);
+        }
+
+        private bool executeHIPContributionCandidates(IEnumerable<HIPContributionCandidate> candidates)
+        {
+            bool contributed = false;
+            foreach (HIPContributionCandidate candidate in candidates)
+            {
+                if (this.CanFindAllItems(candidate.ItemIds) == false)
+                {
+                    if (Globals.Debug)
+                        LogHelper.LogInfo($"(HIP): stale candidate skipped for area {candidate.AreaType}.");
+                    continue;
+                }
+
+                this.hideoutInProgressContribute(candidate.AreaData, candidate.ItemRequirements);
+                contributed = true;
+                foreach (string contributionMessage in candidate.ContributionMessages)
+                    LogHelper.LogInfoWithNotification(contributionMessage);
+            }
+
+            return contributed;
+        }
+
+        private IEnumerator refreshSimpleStashPanels()
+        {
+            //HACK finally found a way to hard refresh the draw of SimpleStashPanel.
+            foreach (SimpleStashPanel simpleStashPanel in this.simpleStashPanels)
+            {
+                ScrollRect? scroll = getStashScroll(simpleStashPanel);
+                float originalPosition = scroll?.verticalNormalizedPosition ?? 1.0f;
+                yield return null; //EndOfFrame
+                forceScrollRefresh(scroll, Mathf.Clamp01(originalPosition - 0.1f));
+                yield return null; //EndOfFrame
+                forceScrollRefresh(scroll, Mathf.Clamp01(originalPosition + 0.2f));
+                yield return null; //EndOfFrame
+                forceScrollRefresh(scroll, originalPosition);
             }
         }
 
@@ -370,6 +485,47 @@ namespace HideoutAutomation.MonoBehaviours
                 || this.lastRemoveItemRequirements != Globals.RemoveItemRequirements
                 || this.lastRemoveSkillRequirements != Globals.RemoveSkillRequirements
                 || this.lastRemoveTraderRequirements != Globals.RemoveTraderRequirements;
+        }
+
+        private void resetHIPContributionConfirmationCycle()
+        {
+            this.hipContributionDeniedThisCycle = false;
+            this.hipContributionScanCompleted = false;
+            this.pendingHIPContributionCandidates.Clear();
+            if (Globals.Debug)
+                LogHelper.LogInfo("(HIP): confirmation cycle reset.");
+        }
+
+        private void tryShowHIPContributionConfirmation()
+        {
+            if (Globals.EnableHIPContributionConfirmation == false
+                || this.hipContributionDeniedThisCycle
+                || this.inDialog
+                || this.pendingHIPContributionCandidates.Count == 0)
+                return;
+
+            string description = this.buildHIPContributionDescription(this.pendingHIPContributionCandidates);
+            if (string.IsNullOrWhiteSpace(description))
+                return;
+
+            HIPContributionCandidate[] candidates = this.pendingHIPContributionCandidates.ToArray();
+            this.pendingHIPContributionCandidates.Clear();
+
+            this.showDialogWindow(description, () =>
+            {
+                if (RaidHelper.HasRaidLoaded())
+                    return;
+
+                if (Globals.Debug)
+                    LogHelper.LogInfo("(HIP): contribution prompt accepted.");
+                if (this.executeHIPContributionCandidates(candidates))
+                    this.StartCoroutine(this.refreshSimpleStashPanels());
+            }, () =>
+            {
+                this.hipContributionDeniedThisCycle = true;
+                if (Globals.Debug)
+                    LogHelper.LogInfo("(HIP): contribution prompt denied.");
+            });
         }
 
         /// <summary>

--- a/MonoBehaviours/UpdateMonoBehaviour.cs
+++ b/MonoBehaviours/UpdateMonoBehaviour.cs
@@ -36,8 +36,8 @@ namespace HideoutAutomation.MonoBehaviours
         private readonly List<HIPContributionCandidate> hipPendingCandidates = [];
         private CancellationToken? cancellationToken;
         private CancellationTokenSource? cancellationTokenSource;
-        private bool checkHIPContributionCycle = false;
         private bool didInvestigate = false;
+        private bool hipCheckContributionCycle = false;
         private bool hipContributionDeniedThisCycle = false;
         private bool hipContributionScanCompleted = false;
         private bool inDialog = false;
@@ -59,15 +59,15 @@ namespace HideoutAutomation.MonoBehaviours
             bool hasRaidLoaded = RaidHelper.HasRaidLoaded();
             if (hasRaidLoaded)
             {
-                this.checkHIPContributionCycle = true;
+                this.hipCheckContributionCycle = true;
                 this.stopCoroutines();
                 return;
             }
 
-            if (this.checkHIPContributionCycle)
+            if (this.hipCheckContributionCycle)
             {
-                this.checkHIPContributionCycle = false;
-                this.resetHIPContributionConfirmationCycle();
+                this.hipCheckContributionCycle = false;
+                this.hideoutInProgressResetContributionConfirmationCycle();
             }
 
             if (this.cancellationToken?.IsCancellationRequested == true)
@@ -91,7 +91,7 @@ namespace HideoutAutomation.MonoBehaviours
             this.stopCoroutines();
 
             this.declinedAreaUpdates.Clear();
-            this.resetHIPContributionConfirmationCycle();
+            this.hideoutInProgressResetContributionConfirmationCycle();
             LogHelper.LogInfoWithNotification($"Declined Area(s) reset.");
 
             this.startCoroutine();
@@ -144,22 +144,6 @@ namespace HideoutAutomation.MonoBehaviours
                 .GetField("_stashScroll", BindingFlags.Instance | BindingFlags.NonPublic);
 
             return field?.GetValue(panel) as ScrollRect;
-        }
-
-        private string buildHIPContributionDescription(IEnumerable<HIPContributionCandidate> candidates)
-        {
-            List<string> lines = [];
-            foreach (HIPContributionCandidate candidate in candidates)
-            {
-                lines.Add($"Area: {candidate.AreaType}");
-                foreach (string contributionMessage in candidate.ContributionMessages)
-                    lines.Add($"- {contributionMessage}");
-            }
-
-            if (lines.Count == 0)
-                return string.Empty;
-
-            return $"Contribute the following Hideout In Progress items?{Environment.NewLine}{Environment.NewLine}{string.Join(Environment.NewLine, lines)}";
         }
 
         private bool CanFindAllItems(IEnumerable<string> itemIds)
@@ -233,14 +217,14 @@ namespace HideoutAutomation.MonoBehaviours
                                 {
                                     if (shouldScanHIPContributions)
                                     {
-                                        HIPContributionCandidate? candidate = this.createHIPContributionCandidate(hideout, data, areaType, requirements);
+                                        HIPContributionCandidate? candidate = this.hideoutInProgressCreateContributionCandidate(hideout, data, areaType, requirements);
                                         if (candidate != null)
                                             this.hipPendingCandidates.Add(candidate);
                                     }
                                 }
                                 else
                                 {
-                                    HIPContributionCandidate? candidate = this.createHIPContributionCandidate(hideout, data, areaType, requirements);
+                                    HIPContributionCandidate? candidate = this.hideoutInProgressCreateContributionCandidate(hideout, data, areaType, requirements);
                                     if (candidate != null)
                                     {
                                         this.hideoutInProgressContribute(candidate.AreaData, candidate.ItemRequirements);
@@ -303,58 +287,6 @@ namespace HideoutAutomation.MonoBehaviours
                     }
                 }
             }
-        }
-
-        private HIPContributionCandidate? createHIPContributionCandidate(HideoutClass hideout, AreaData data, EAreaType areaType, List<Requirement> requirements)
-        {
-            if (Globals.Debug)
-                LogHelper.LogInfo($"(HIP): CheckItemRequirements.");
-
-            List<string> itemIds = [];
-            List<string> contributionMessages = [];
-            ItemRequirement[] itemRequirements = requirements.OfType<ItemRequirement>().Where(r => r.Item is not MoneyItemClass).ToArray();
-            foreach (ItemRequirement itemRequirement in itemRequirements)
-            {
-                var contributions = hideout.method_21([itemRequirement]);
-                if (contributions.Count > 0)
-                {
-                    if (Globals.Debug)
-                        LogHelper.LogInfo($"(HIP): contributions.Count={contributions.Count}");
-                    foreach (var contribution in contributions)
-                    {
-                        string itemId = contribution.Item.Id;
-                        string contributionMessage = $"Contribute {contribution.CurrentItemCount} of {contribution.Item.LocalizedName()} to {areaType}.";
-                        itemIds.Add(itemId);
-                        contributionMessages.Add(contributionMessage);
-                    }
-                }
-            }
-
-            if (itemIds.Count == 0 || this.CanFindAllItems(itemIds) == false)
-                return null;
-
-            return new HIPContributionCandidate(data, areaType, itemRequirements, itemIds, contributionMessages);
-        }
-
-        private bool executeHIPContributionCandidates(IEnumerable<HIPContributionCandidate> candidates)
-        {
-            bool contributed = false;
-            foreach (HIPContributionCandidate candidate in candidates)
-            {
-                if (this.CanFindAllItems(candidate.ItemIds) == false)
-                {
-                    if (Globals.Debug)
-                        LogHelper.LogInfo($"(HIP): stale candidate skipped for area {candidate.AreaType}.");
-                    continue;
-                }
-
-                this.hideoutInProgressContribute(candidate.AreaData, candidate.ItemRequirements);
-                contributed = true;
-                foreach (string contributionMessage in candidate.ContributionMessages)
-                    LogHelper.LogInfoWithNotification(contributionMessage);
-            }
-
-            return contributed;
         }
 
         private int getItemCount(string templateId, bool isSpawnedInSession)
@@ -447,32 +379,6 @@ namespace HideoutAutomation.MonoBehaviours
                 || this.lastRemoveItemRequirements != Globals.RemoveItemRequirements
                 || this.lastRemoveSkillRequirements != Globals.RemoveSkillRequirements
                 || this.lastRemoveTraderRequirements != Globals.RemoveTraderRequirements;
-        }
-
-        /// <summary>
-        /// Calls hip Transferbutton.Contribute() function.
-        /// https://github.com/tyfon7/hip/blob/main/src/TransferButton.cs
-        /// </summary>
-        /// <returns></returns>
-        private void hideoutInProgressContribute(AreaData areaData, ItemRequirement[] itemRequirements)
-        {
-            Type? transferButtonType = Globals.HIPTransferButtonType;
-            if (Globals.Debug)
-                LogHelper.LogInfo($"(HIP): transferButtonType={transferButtonType}");
-            if (transferButtonType != null)
-            {
-                object transferButton = Activator.CreateInstance(transferButtonType);
-                Globals.HIPItemRequirementsFieldInfo?.SetValue(transferButton, itemRequirements);
-                Globals.HIPAreaDataFieldInfo?.SetValue(transferButton, areaData);
-                Globals.HIPContributeMethodInfo?.Invoke(transferButton, null);
-            }
-        }
-
-        private bool hideoutInProgressRequirementsAreMet(List<Requirement> requirements)
-        {
-            if (Globals.OnlyContributeWhenAreaRequirementsAreMet == false)
-                return true;
-            return requirements.OfType<AreaRequirement>().Any(r => r.Fulfilled == false) == false;
         }
 
         private void investigate()
@@ -623,15 +529,6 @@ namespace HideoutAutomation.MonoBehaviours
             return requirements.Data;
         }
 
-        private void resetHIPContributionConfirmationCycle()
-        {
-            this.hipContributionDeniedThisCycle = false;
-            this.hipContributionScanCompleted = false;
-            this.hipPendingCandidates.Clear();
-            if (Globals.Debug)
-                LogHelper.LogInfo("(HIP): confirmation cycle reset.");
-        }
-
         private void showDialogWindow(string description, Action acceptAction, Action cancelAction)
         {
             if (this.inDialog)
@@ -672,6 +569,111 @@ namespace HideoutAutomation.MonoBehaviours
                 LogHelper.LogInfoWithNotification("Stopped coroutine");
         }
 
+        #region HideoutInProgress
+
+        private string hideoutInProgressBuildContributionDescription(IEnumerable<HIPContributionCandidate> candidates)
+        {
+            List<string> lines = [];
+            foreach (HIPContributionCandidate candidate in candidates)
+            {
+                lines.Add($"Area: {candidate.AreaType}");
+                foreach (string contributionMessage in candidate.ContributionMessages)
+                    lines.Add($"- {contributionMessage}");
+            }
+
+            if (lines.Count == 0)
+                return string.Empty;
+
+            return $"Contribute the following Hideout In Progress items?{Environment.NewLine}{Environment.NewLine}{string.Join(Environment.NewLine, lines)}";
+        }
+
+        /// <summary>
+        /// Calls hip Transferbutton.Contribute() function.
+        /// https://github.com/tyfon7/hip/blob/main/src/TransferButton.cs
+        /// </summary>
+        /// <returns></returns>
+        private void hideoutInProgressContribute(AreaData areaData, ItemRequirement[] itemRequirements)
+        {
+            Type? transferButtonType = Globals.HIPTransferButtonType;
+            if (Globals.Debug)
+                LogHelper.LogInfo($"(HIP): transferButtonType={transferButtonType}");
+            if (transferButtonType != null)
+            {
+                object transferButton = Activator.CreateInstance(transferButtonType);
+                Globals.HIPItemRequirementsFieldInfo?.SetValue(transferButton, itemRequirements);
+                Globals.HIPAreaDataFieldInfo?.SetValue(transferButton, areaData);
+                Globals.HIPContributeMethodInfo?.Invoke(transferButton, null);
+            }
+        }
+
+        private HIPContributionCandidate? hideoutInProgressCreateContributionCandidate(HideoutClass hideout, AreaData data, EAreaType areaType, List<Requirement> requirements)
+        {
+            if (Globals.Debug)
+                LogHelper.LogInfo($"(HIP): CheckItemRequirements.");
+
+            List<string> itemIds = [];
+            List<string> contributionMessages = [];
+            ItemRequirement[] itemRequirements = requirements.OfType<ItemRequirement>().Where(r => r.Item is not MoneyItemClass).ToArray();
+            foreach (ItemRequirement itemRequirement in itemRequirements)
+            {
+                var contributions = hideout.method_21([itemRequirement]);
+                if (contributions.Count > 0)
+                {
+                    if (Globals.Debug)
+                        LogHelper.LogInfo($"(HIP): contributions.Count={contributions.Count}");
+                    foreach (var contribution in contributions)
+                    {
+                        string itemId = contribution.Item.Id;
+                        string contributionMessage = $"Contribute {contribution.CurrentItemCount} of {contribution.Item.LocalizedName()} to {areaType}.";
+                        itemIds.Add(itemId);
+                        contributionMessages.Add(contributionMessage);
+                    }
+                }
+            }
+
+            if (itemIds.Count == 0 || this.CanFindAllItems(itemIds) == false)
+                return null;
+
+            return new HIPContributionCandidate(data, areaType, itemRequirements, itemIds, contributionMessages);
+        }
+
+        private bool hideoutInProgressExecuteContributionCandidates(IEnumerable<HIPContributionCandidate> candidates)
+        {
+            bool contributed = false;
+            foreach (HIPContributionCandidate candidate in candidates)
+            {
+                if (this.CanFindAllItems(candidate.ItemIds) == false)
+                {
+                    if (Globals.Debug)
+                        LogHelper.LogInfo($"(HIP): stale candidate skipped for area {candidate.AreaType}.");
+                    continue;
+                }
+
+                this.hideoutInProgressContribute(candidate.AreaData, candidate.ItemRequirements);
+                contributed = true;
+                foreach (string contributionMessage in candidate.ContributionMessages)
+                    LogHelper.LogInfoWithNotification(contributionMessage);
+            }
+
+            return contributed;
+        }
+
+        private bool hideoutInProgressRequirementsAreMet(List<Requirement> requirements)
+        {
+            if (Globals.OnlyContributeWhenAreaRequirementsAreMet == false)
+                return true;
+            return requirements.OfType<AreaRequirement>().Any(r => r.Fulfilled == false) == false;
+        }
+
+        private void hideoutInProgressResetContributionConfirmationCycle()
+        {
+            this.hipContributionDeniedThisCycle = false;
+            this.hipContributionScanCompleted = false;
+            this.hipPendingCandidates.Clear();
+            if (Globals.Debug)
+                LogHelper.LogInfo("(HIP): confirmation cycle reset.");
+        }
+
         private void tryShowHIPContributionConfirmation()
         {
             if (Globals.EnableHideoutInProgressConfirmation == false
@@ -680,7 +682,7 @@ namespace HideoutAutomation.MonoBehaviours
                 || this.hipPendingCandidates.Count == 0)
                 return;
 
-            string description = this.buildHIPContributionDescription(this.hipPendingCandidates);
+            string description = this.hideoutInProgressBuildContributionDescription(this.hipPendingCandidates);
             if (string.IsNullOrWhiteSpace(description))
                 return;
 
@@ -694,7 +696,7 @@ namespace HideoutAutomation.MonoBehaviours
 
                 if (Globals.Debug)
                     LogHelper.LogInfo("(HIP): contribution prompt accepted.");
-                if (this.executeHIPContributionCandidates(candidates))
+                if (this.hideoutInProgressExecuteContributionCandidates(candidates))
                     this.StartCoroutine(this.refreshSimpleStashPanels());
             }, () =>
             {
@@ -703,5 +705,7 @@ namespace HideoutAutomation.MonoBehaviours
                     LogHelper.LogInfo("(HIP): contribution prompt denied.");
             });
         }
+
+        #endregion HideoutInProgress
     }
 }

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -12,7 +12,7 @@ namespace HideoutAutomation
     [BepInPlugin("com.KnotScripts.HideoutAutomation", "HideoutAutomation", VERSION)]
     public class Plugin : BaseUnityPlugin
     {
-        public const string VERSION = "1.2.6";
+        public const string VERSION = "1.3.0";
 
         private ConfigEntry<bool> autoConstruct;
         private ConfigEntry<bool> autoInstall;

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -18,6 +18,7 @@ namespace HideoutAutomation
         private ConfigEntry<bool> autoInstall;
         private ConfigEntry<bool> autoUpgrade;
         private ConfigEntry<bool> debug;
+        private ConfigEntry<bool> enableHIPContributionConfirmation;
         private ConfigEntry<bool> enableHideoutInProgressSupport;
         private ConfigEntry<bool> enableProductionStacking;
         private ConfigEntry<bool> onlyContributeWhenAreaRequirementsAreMet;
@@ -108,6 +109,9 @@ namespace HideoutAutomation
             this.enableHideoutInProgressSupport = this.Config.Bind("HideoutInProgress", "EnableHideoutInProgressSupport", true, "Experimental (HIP mod support). Disable when problems occur.");
             this.enableHideoutInProgressSupport.SettingChanged += this.global_SettingChanged;
 
+            this.enableHIPContributionConfirmation = this.Config.Bind("HideoutInProgress", "EnableHIPContributionConfirmation", true, "(HIP mod support) Ask confirmation before contributing items after raid.");
+            this.enableHIPContributionConfirmation.SettingChanged += this.global_SettingChanged;
+
             this.onlyContributeWhenAreaRequirementsAreMet = this.Config.Bind("HideoutInProgress", "OnlyContributeWhenAreaRequirementsAreMet", true, "(HIP mod support) Only contribute when area requirements are met.");
             this.onlyContributeWhenAreaRequirementsAreMet.SettingChanged += this.global_SettingChanged;
 
@@ -128,6 +132,7 @@ namespace HideoutAutomation
             Globals.ResetDeclinedAreaUpdates = this.resetDeclinedAreaUpdates.Value;
             Globals.ThresholdCurrencyHandover = this.thresholdCurrencyHandover.Value;
             Globals.UseDialogWindow = this.useDialogWindow.Value;
+            Globals.EnableHIPContributionConfirmation = this.enableHIPContributionConfirmation.Value;
             Globals.OnlyContributeWhenAreaRequirementsAreMet = this.onlyContributeWhenAreaRequirementsAreMet.Value;
             Globals.IsHideoutInProgressSupportEnabled = this.enableHideoutInProgressSupport.Value;
             Globals.ProductionStacking = this.enableProductionStacking.Value;

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -18,7 +18,7 @@ namespace HideoutAutomation
         private ConfigEntry<bool> autoInstall;
         private ConfigEntry<bool> autoUpgrade;
         private ConfigEntry<bool> debug;
-        private ConfigEntry<bool> enableHIPContributionConfirmation;
+        private ConfigEntry<bool> enableHideoutInProgressConfirmation;
         private ConfigEntry<bool> enableHideoutInProgressSupport;
         private ConfigEntry<bool> enableProductionStacking;
         private ConfigEntry<bool> onlyContributeWhenAreaRequirementsAreMet;
@@ -106,11 +106,11 @@ namespace HideoutAutomation
             this.enableProductionStacking = this.Config.Bind("ProductionStacking", "EnableProductionStacking", true, "(experimental) enable production stacking.");
             this.enableProductionStacking.SettingChanged += this.global_SettingChanged;
 
-            this.enableHideoutInProgressSupport = this.Config.Bind("HideoutInProgress", "EnableHideoutInProgressSupport", true, "Experimental (HIP mod support). Disable when problems occur.");
+            this.enableHideoutInProgressSupport = this.Config.Bind("HideoutInProgress", "EnableHideoutInProgressSupport", true, "HIP mod support.");
             this.enableHideoutInProgressSupport.SettingChanged += this.global_SettingChanged;
 
-            this.enableHIPContributionConfirmation = this.Config.Bind("HideoutInProgress", "EnableHIPContributionConfirmation", true, "(HIP mod support) Ask confirmation before contributing items after raid.");
-            this.enableHIPContributionConfirmation.SettingChanged += this.global_SettingChanged;
+            this.enableHideoutInProgressConfirmation = this.Config.Bind("HideoutInProgress", "EnableHideoutInProgressConfirmation", true, "(HIP mod support) Ask for confirmation once before contributing items after a raid.");
+            this.enableHideoutInProgressConfirmation.SettingChanged += this.global_SettingChanged;
 
             this.onlyContributeWhenAreaRequirementsAreMet = this.Config.Bind("HideoutInProgress", "OnlyContributeWhenAreaRequirementsAreMet", true, "(HIP mod support) Only contribute when area requirements are met.");
             this.onlyContributeWhenAreaRequirementsAreMet.SettingChanged += this.global_SettingChanged;
@@ -132,7 +132,7 @@ namespace HideoutAutomation
             Globals.ResetDeclinedAreaUpdates = this.resetDeclinedAreaUpdates.Value;
             Globals.ThresholdCurrencyHandover = this.thresholdCurrencyHandover.Value;
             Globals.UseDialogWindow = this.useDialogWindow.Value;
-            Globals.EnableHIPContributionConfirmation = this.enableHIPContributionConfirmation.Value;
+            Globals.EnableHideoutInProgressConfirmation = this.enableHideoutInProgressConfirmation.Value;
             Globals.OnlyContributeWhenAreaRequirementsAreMet = this.onlyContributeWhenAreaRequirementsAreMet.Value;
             Globals.IsHideoutInProgressSupportEnabled = this.enableHideoutInProgressSupport.Value;
             Globals.ProductionStacking = this.enableProductionStacking.Value;


### PR DESCRIPTION
Feature made by @awnova:

---

feat: add config option HIP contribution confirm prompt after raid
- collects all HIP item contributions into one prompt after raid
- accept = contribute all
- decline = skip until next raid
- Ctrl+H resets the declined state

---

Fixed naming of the areas in the HIP contribution messages by @PMouse23

---

@awnova I saw your changes to the mod regarding the HIP support and checked them out. I liked it so i pulled it in and made some little *naming* changes.

Is this your Forge profile for a honorable mention?
[https://forge.sp-tarkov.com/user/106828/awnova](https://forge.sp-tarkov.com/user/106828/awnova)

**And remember:**
[You're The Best!](https://music.youtube.com/watch?v=p44G0U4sLCE&list=OLAK5uy_ksm4b2BrEfTjyc6c3rOHMACAjkYVgwWr4)